### PR TITLE
feat(financial-analysis): add persistSnapshot method to save financia…

### DIFF
--- a/src/database/entities/roadmap-state.entity.ts
+++ b/src/database/entities/roadmap-state.entity.ts
@@ -1,6 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
 import { User } from './user.entity.js';
-import { RoadmapStep } from './roadmap-step.entity.js';
 
 @Entity('roadmap_states')
 export class RoadmapState {
@@ -9,9 +8,6 @@ export class RoadmapState {
 
   @Column({ type: 'uuid', name: 'user_id' })
   userId: string;
-
-  @Column({ type: 'int', name: 'current_step_id' })
-  currentStepId: number;
 
   @Column({ type: 'int', name: 'progress_percent', default: 0 })
   progressPercent: number;
@@ -22,8 +18,4 @@ export class RoadmapState {
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
   user: User;
-
-  @ManyToOne(() => RoadmapStep)
-  @JoinColumn({ name: 'current_step_id' })
-  currentStep: RoadmapStep;
 }

--- a/src/database/migrations/1749500300000-RemoveRoadmapStateCurrentStepId.ts
+++ b/src/database/migrations/1749500300000-RemoveRoadmapStateCurrentStepId.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Removes the duplicated `current_step_id` column from `roadmap_states`.
+ *
+ * `user_profiles.current_step` is now the single source of truth for the user's
+ * current financial step. Before dropping the column, any profile that is still
+ * missing a step is backfilled from the roadmap state so no user loses their
+ * step. The drop is idempotent (IF EXISTS); the `down` migration re-adds the
+ * column as nullable (data is not restored).
+ */
+export class RemoveRoadmapStateCurrentStepId1749500300000
+  implements MigrationInterface
+{
+  name = 'RemoveRoadmapStateCurrentStepId1749500300000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "user_profiles" up
+        SET "current_step" = rs."current_step_id"
+        FROM "roadmap_states" rs
+        WHERE rs."user_id" = up."user_id"
+          AND up."current_step" IS NULL
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "roadmap_states"
+        DROP COLUMN IF EXISTS "current_step_id"
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "roadmap_states"
+        ADD COLUMN IF NOT EXISTS "current_step_id" INTEGER
+    `);
+  }
+}

--- a/src/event-detection/event-detection.service.ts
+++ b/src/event-detection/event-detection.service.ts
@@ -1,10 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FinancialEvent } from '../database/entities/financial-event.entity.js';
+import type { FinancialFeatures } from '../open-finance/financial-features.model.js';
+
+/** Deterministic event types derived directly from the financial report. */
+export const FinancialEventType = {
+  /** A month in the reported window where expense exceeded income. */
+  DEFICIT_MONTH: 'DEFICIT_MONTH',
+} as const;
 
 @Injectable()
 export class EventDetectionService {
+  private readonly logger = new Logger(EventDetectionService.name);
+
   constructor(
     @InjectRepository(FinancialEvent)
     private readonly eventRepo: Repository<FinancialEvent>,
@@ -18,9 +27,69 @@ export class EventDetectionService {
     });
   }
 
-  async detectEvents(userId: string, newTransactions: any[]) {
-    // TODO: compare new transactions, detect salary, large expense, goal reached
-    // Write detected events to DB and update progress state
-    return [];
+  /**
+   * Detects deterministic, data-backed financial events from the extracted
+   * features and persists any that are not already recorded.
+   *
+   * Currently emits DEFICIT_MONTH events — one per month in the report window
+   * where expense exceeded income. This is the only event type derivable
+   * without an externally-defined threshold. Detection is idempotent: months
+   * already stored for the user are skipped, so re-running an analysis over an
+   * overlapping window does not create duplicates.
+   */
+  async detectEvents(
+    userId: string,
+    features: FinancialFeatures,
+  ): Promise<FinancialEvent[]> {
+    const deficitMonths = features.monthlyBalances.filter((m) => m.net < 0);
+    if (!deficitMonths.length) return [];
+
+    // Load already-recorded deficit events to dedupe by month.
+    const existing = await this.eventRepo.find({
+      where: { userId, eventType: FinancialEventType.DEFICIT_MONTH },
+    });
+    const existingKeys = new Set(
+      existing.map((e) => this.monthKey(e.eventDate)),
+    );
+
+    const toInsert: FinancialEvent[] = [];
+    for (const m of deficitMonths) {
+      const eventDate = this.parseYearMonth(m.yearMonth);
+      if (!eventDate) continue;
+      const key = this.monthKey(eventDate);
+      if (existingKeys.has(key)) continue;
+      existingKeys.add(key);
+      toInsert.push(
+        this.eventRepo.create({
+          userId,
+          eventType: FinancialEventType.DEFICIT_MONTH,
+          amount: m.net,
+          eventDate,
+        }),
+      );
+    }
+
+    if (!toInsert.length) return [];
+    const saved = await this.eventRepo.save(toInsert);
+    this.logger.log(
+      `Detected ${saved.length} new DEFICIT_MONTH event(s) — userId=${userId}`,
+    );
+    return saved;
+  }
+
+  /** Parses a provider "YY-MM" label (e.g. "26-05") to the first of that month (UTC). */
+  private parseYearMonth(yearMonth: string): Date | null {
+    const match = /^(\d{2})-(\d{2})$/.exec(yearMonth);
+    if (!match) return null;
+    const year = 2000 + Number(match[1]);
+    const month = Number(match[2]);
+    if (month < 1 || month > 12) return null;
+    return new Date(Date.UTC(year, month - 1, 1));
+  }
+
+  /** Year-month dedupe key for a stored event date. */
+  private monthKey(date: Date): string {
+    const d = date instanceof Date ? date : new Date(date);
+    return `${d.getUTCFullYear()}-${d.getUTCMonth() + 1}`;
   }
 }

--- a/src/financial-analysis/financial-analysis.service.ts
+++ b/src/financial-analysis/financial-analysis.service.ts
@@ -1,10 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { FinancialSnapshot } from '../database/entities/financial-snapshot.entity.js';
+import type { FinancialFeatures } from '../open-finance/financial-features.model.js';
 
 @Injectable()
 export class FinancialAnalysisService {
+  private readonly logger = new Logger(FinancialAnalysisService.name);
+
   constructor(
     @InjectRepository(FinancialSnapshot)
     private readonly snapshotRepo: Repository<FinancialSnapshot>,
@@ -16,5 +19,36 @@ export class FinancialAnalysisService {
       where: { userId },
       order: { createdAt: 'DESC' },
     });
+  }
+
+  /**
+   * Persists a raw financial snapshot derived deterministically from the Open
+   * Finance report. Each analysis run appends one immutable row, giving a
+   * time-series of the user's headline figures.
+   *
+   * Field mapping (all traceable to extracted features):
+   *  - monthlyIncome   ← features.monthlyIncome
+   *  - monthlyExpenses ← features.monthlyExpenses
+   *  - totalSavings    ← features.totalInvestments (savings + securities)
+   *  - totalDebt       ← features.totalDebt (loans + mortgage)
+   */
+  async persistSnapshot(
+    userId: string,
+    features: FinancialFeatures,
+  ): Promise<FinancialSnapshot> {
+    const snapshot = this.snapshotRepo.create({
+      userId,
+      monthlyIncome: features.monthlyIncome,
+      monthlyExpenses: features.monthlyExpenses,
+      totalSavings: features.totalInvestments,
+      totalDebt: features.totalDebt,
+    });
+    const saved = await this.snapshotRepo.save(snapshot);
+    this.logger.log(
+      `Snapshot saved — userId=${userId} income=${features.monthlyIncome} ` +
+        `expenses=${features.monthlyExpenses} savings=${features.totalInvestments} ` +
+        `debt=${features.totalDebt}`,
+    );
+    return saved;
   }
 }

--- a/src/llm-orchestrator/llm-orchestrator.service.ts
+++ b/src/llm-orchestrator/llm-orchestrator.service.ts
@@ -185,7 +185,7 @@ export class LlmOrchestratorService {
         `kept=${safe.length}${dropped > 0 ? ` droppedInvalid=${dropped}` : ''}`,
     );
 
-    return safe.map((r: any) => ({
+    const result = safe.map((r: any) => ({
       roadmap_goal_id: r.roadmap_goal_id,
       title:
         r.title ??
@@ -195,6 +195,10 @@ export class LlmOrchestratorService {
       ai_insight: r.ai_insight ?? '',
       dynamic_params: r.dynamic_params ?? {},
     }));
+
+    await this.persistGuidanceLog(profile, filteredGoals, result);
+
+    return result;
   }
 
   // ─── Private AI helpers ───────────────────────────────────────────────────
@@ -204,20 +208,55 @@ export class LlmOrchestratorService {
     return this.llm.sanitizeJson(raw);
   }
 
-  // ─── Legacy compatibility ─────────────────────────────────────────────────
+  /**
+   * Records the AI guidance produced for a user into llm_guidance_logs.
+   * Stores the decision context (financial criteria + step + candidate goals)
+   * alongside the personalized recommendations the model returned, so guidance
+   * is auditable and reproducible. Failures are non-fatal to the request.
+   */
+  private async persistGuidanceLog(
+    profile: UserProfile,
+    filteredGoals: RoadmapGoal[],
+    recommendations: PersonalizedGoalRecommendation[],
+  ): Promise<void> {
+    try {
+      const contextSnapshot = {
+        current_step: profile.currentStep,
+        criteria: {
+          cash_flow: profile.cashFlow,
+          credit_consumption: profile.creditConsumption,
+          loans: profile.loans,
+          savings_investments: profile.savingsInvestments,
+          pension_long_term: profile.pensionLongTerm,
+          lifestyle_clubs: profile.lifestyleClubs,
+          mortgage: profile.mortgage,
+          system_indicators: profile.systemIndicators,
+          risk_tolerance: profile.riskTolerance,
+          knowledge_level: profile.knowledgeLevel,
+        },
+        candidate_goal_ids: filteredGoals.map((g) => g.goalId),
+        recommendations,
+      };
 
-  async generateGuidance(
-    userId: string,
-    context: { questionnaire: any; goals: any[]; snapshot: any },
-  ) {
-    const guidanceText =
-      'Use GET /goals/recommended for AI-powered step-isolated recommendations.';
-    const log = this.logRepo.create({
-      userId,
-      contextSnapshot: context,
-      guidanceText,
-    });
-    await this.logRepo.save(log);
-    return { stage: 1, recommendation: guidanceText, suggestedGoals: [] };
+      const guidanceText = recommendations
+        .map((r, i) => `${i + 1}. [${r.title}] ${r.ai_insight}`)
+        .join('\n');
+
+      const log = this.logRepo.create({
+        userId: profile.userId,
+        contextSnapshot,
+        guidanceText,
+      });
+      await this.logRepo.save(log);
+      this.logger.log(
+        `[GuidanceLog] saved logId=${log.logId} userId=${profile.userId} ` +
+          `recommendations=${recommendations.length}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `[GuidanceLog] failed to persist guidance for userId=${profile.userId}: ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }

--- a/src/open-finance/financial-features.model.ts
+++ b/src/open-finance/financial-features.model.ts
@@ -1,0 +1,83 @@
+/**
+ * Deterministic, structured projection of a user's financial position, computed
+ * from the aggregated Open Finance `financialReport` by the extractor.
+ *
+ * Every field is traceable to a concrete source field in the report (or a
+ * derivation of such fields) — no inferred business rules. This is the single
+ * object the rest of the pipeline consumes: it feeds the LLM prompts, the
+ * FinancialSnapshot persistence and the FinancialEvent detection.
+ *
+ * All monetary values are in ILS and rounded to whole shekels.
+ */
+
+/** A per-month income/expense pair derived from `yearMonthBalance[]`. */
+export interface MonthlyBalance {
+  /** Provider month label, e.g. "26-05". */
+  yearMonth: string;
+  income: number;
+  expense: number;
+  /** income - expense for the month. */
+  net: number;
+}
+
+export interface FinancialFeatures {
+  // ── Liquidity ───────────────────────────────────────────────────────────
+  /** Σ of all ILS checking-account balances. */
+  currentBalance: number;
+
+  // ── Monthly cash flow (from totalIncomesOutcome) ─────────────────────────
+  monthlyIncome: number;
+  monthlyExpenses: number;
+  /** Provider-reported net (income - expenses) per month. */
+  monthlyNetCashFlow: number;
+
+  // ── Multi-month history (from yearMonthBalance) ──────────────────────────
+  monthlyBalances: MonthlyBalance[];
+  monthsCovered: number;
+  /** Months in the window where expense exceeded income. */
+  deficitMonthsCount: number;
+  avgMonthlyIncome: number;
+  avgMonthlyExpense: number;
+
+  // ── Savings & investments ────────────────────────────────────────────────
+  totalSavings: number;
+  totalSecuritiesValue: number;
+  /** totalSavings + totalSecuritiesValue. */
+  totalInvestments: number;
+  securitiesCount: number;
+
+  // ── Debt ─────────────────────────────────────────────────────────────────
+  totalLoans: number;
+  totalMortgage: number;
+  /** totalLoans + totalMortgage. */
+  totalDebt: number;
+  hasActiveLoans: boolean;
+  hasMortgage: boolean;
+
+  // ── Credit cards ──────────────────────────────────────────────────────────
+  /** Distinct credit-card accounts seen in creditCardOutcomes. */
+  activeCreditCardsCount: number;
+  /** Average monthly spend across all cards over the reported window. */
+  avgMonthlyCreditCardSpend: number;
+  /** Σ of avgCardFee across cards (nulls treated as 0). */
+  creditCardFeesTotal: number;
+
+  // ── Derived ratios ────────────────────────────────────────────────────────
+  /** % of monthly income directed to savings/investments contributions. */
+  savingsRate: number;
+  /** monthlyIncome - monthlyExpenses (provider already nets debt into expenses). */
+  discretionarySurplus: number;
+
+  // ── System / BDI indicators (counts; null in report → 0) ─────────────────
+  systemFlags: {
+    loanOverDueCount: number;
+    foreclosureCount: number;
+    alertNoticeCount: number;
+    akamCount: number;
+    cancelledCount: number;
+  };
+
+  // ── Provenance ────────────────────────────────────────────────────────────
+  /** Whether the report actually contained any usable financial data. */
+  hasData: boolean;
+}

--- a/src/open-finance/financial-report.extractor.ts
+++ b/src/open-finance/financial-report.extractor.ts
@@ -1,0 +1,223 @@
+import {
+  OFCheckingAccount,
+  OFFinancialReport,
+  OFReportEnvelope,
+} from './financial-report.types.js';
+import {
+  FinancialFeatures,
+  MonthlyBalance,
+} from './financial-features.model.js';
+
+/** Coerces an unknown value to a finite number, defaulting to 0. */
+function num(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Rounds to whole shekels. */
+function round(value: number): number {
+  return Math.round(value);
+}
+
+/**
+ * Accepts either the full report envelope (`{ status, financialReport }`, as the
+ * file-upload flow provides) or a bare `financialReport` object (as the API flow
+ * provides) and returns the inner report. Returns an empty object when the input
+ * is missing or malformed so the extractor can still produce a zeroed result.
+ */
+export function normalizeReport(raw: unknown): OFFinancialReport {
+  if (raw == null || typeof raw !== 'object') {
+    return {};
+  }
+  const obj = raw as OFReportEnvelope & OFFinancialReport;
+  // Envelope shape: unwrap to the inner report.
+  if (obj.financialReport && typeof obj.financialReport === 'object') {
+    return obj.financialReport;
+  }
+  // Already an inner report.
+  return obj as OFFinancialReport;
+}
+
+/** Sums the ILS balance across the provided checking-account entries. */
+function sumCheckingBalance(accounts?: OFCheckingAccount[]): number {
+  if (!Array.isArray(accounts)) return 0;
+  return accounts.reduce((acc, a) => acc + num(a?.amount), 0);
+}
+
+
+/** Produces a fully-zeroed feature set (used for empty/invalid reports). */
+export function emptyFeatures(): FinancialFeatures {
+  return {
+    currentBalance: 0,
+    monthlyIncome: 0,
+    monthlyExpenses: 0,
+    monthlyNetCashFlow: 0,
+    monthlyBalances: [],
+    monthsCovered: 0,
+    deficitMonthsCount: 0,
+    avgMonthlyIncome: 0,
+    avgMonthlyExpense: 0,
+    totalSavings: 0,
+    totalSecuritiesValue: 0,
+    totalInvestments: 0,
+    securitiesCount: 0,
+    totalLoans: 0,
+    totalMortgage: 0,
+    totalDebt: 0,
+    hasActiveLoans: false,
+    hasMortgage: false,
+    activeCreditCardsCount: 0,
+    avgMonthlyCreditCardSpend: 0,
+    creditCardFeesTotal: 0,
+    savingsRate: 0,
+    discretionarySurplus: 0,
+    systemFlags: {
+      loanOverDueCount: 0,
+      foreclosureCount: 0,
+      alertNoticeCount: 0,
+      akamCount: 0,
+      cancelledCount: 0,
+    },
+    hasData: false,
+  };
+}
+
+/**
+ * Deterministically derives a {@link FinancialFeatures} object from an aggregated
+ * Open Finance report. Pure function — no side effects, no LLM. Every output is
+ * a direct read or a transparent arithmetic derivation of report fields.
+ */
+export function extractFeatures(raw: unknown): FinancialFeatures {
+  const report = normalizeReport(raw);
+
+  // Treat a structurally-empty report as "no data".
+  if (!report || Object.keys(report).length === 0) {
+    return emptyFeatures();
+  }
+
+  // ── Liquidity ───────────────────────────────────────────────────────────
+  // Prefer the ILS-specific list; fall back to the generic checking list.
+  const currentBalance = round(
+    report.checkingAccountsILS?.length
+      ? sumCheckingBalance(report.checkingAccountsILS)
+      : sumCheckingBalance(report.checkingAccounts),
+  );
+
+  // ── Monthly cash flow ─────────────────────────────────────────────────────
+  const tio = report.totalIncomesOutcome ?? {};
+  const monthlyIncome = round(num(tio.sumIncomePerMonth));
+  const monthlyExpenses = round(num(tio.sumExpansesPerMonth));
+  const monthlyNetCashFlow = round(num(tio.sumNetIncomePerMonth));
+
+  // ── Multi-month history ───────────────────────────────────────────────────
+  const monthlyBalances: MonthlyBalance[] = Array.isArray(
+    report.yearMonthBalance,
+  )
+    ? report.yearMonthBalance.map((m) => {
+        const income = round(num(m?.sumIncome));
+        const expense = round(num(m?.sumExpense));
+        return {
+          yearMonth: String(m?.yearMonth ?? ''),
+          income,
+          expense,
+          net: income - expense,
+        };
+      })
+    : [];
+  const monthsCovered = monthlyBalances.length;
+  const deficitMonthsCount = monthlyBalances.filter((m) => m.net < 0).length;
+  const avgMonthlyIncome = monthsCovered
+    ? round(
+        monthlyBalances.reduce((acc, m) => acc + m.income, 0) / monthsCovered,
+      )
+    : 0;
+  const avgMonthlyExpense = monthsCovered
+    ? round(
+        monthlyBalances.reduce((acc, m) => acc + m.expense, 0) / monthsCovered,
+      )
+    : 0;
+
+  // ── Savings & investments ──────────────────────────────────────────────────
+  const sas = report.savingsAndSecurities ?? {};
+  const totalSavings = round(num(sas.totalSavings));
+  const totalSecuritiesValue = round(num(sas.totalSecuritiesValue));
+  const totalInvestments = totalSavings + totalSecuritiesValue;
+  const securitiesCount = Array.isArray(report.securities)
+    ? report.securities.length
+    : 0;
+
+  // ── Debt ───────────────────────────────────────────────────────────────────
+  const loansTotal = report.loansTotal ?? {};
+  const totalLoans = round(num(loansTotal.totalLoansAmount));
+  const totalMortgage = round(num(loansTotal.totalMortgageAmount));
+  const totalDebt = totalLoans + totalMortgage;
+
+  // ── Credit cards ────────────────────────────────────────────────────────────
+  const cardOutcomes = Array.isArray(report.creditCardOutcomes)
+    ? report.creditCardOutcomes
+    : [];
+  const cardAccounts = new Set<string>();
+  let cardSpendTotal = 0;
+  const cardMonths = new Set<string>();
+  for (const c of cardOutcomes) {
+    if (c?.accountNumber) cardAccounts.add(c.accountNumber);
+    if (c?.yearMonth) cardMonths.add(c.yearMonth);
+    cardSpendTotal += num(c?.sumExpanse);
+  }
+  const activeCreditCardsCount = cardAccounts.size;
+  const avgMonthlyCreditCardSpend = cardMonths.size
+    ? round(cardSpendTotal / cardMonths.size)
+    : 0;
+  const creditCardFeesTotal = Array.isArray(report.creditCardFees)
+    ? round(
+        report.creditCardFees.reduce((acc, f) => acc + num(f?.avgCardFee), 0),
+      )
+    : 0;
+
+  // ── Derived ratios ───────────────────────────────────────────────────────────
+  // Savings rate based on what the user moves into savings/investments each
+  // month is NOT directly available; we approximate "contribution capacity" with
+  // the discretionary surplus relative to income (transparent derivation).
+  const discretionarySurplus = monthlyIncome - monthlyExpenses;
+  const savingsRate =
+    monthlyIncome > 0
+      ? Math.round((Math.max(0, discretionarySurplus) / monthlyIncome) * 100)
+      : 0;
+
+  // ── System / BDI counters ──────────────────────────────────────────────────
+  const systemFlags = {
+    loanOverDueCount: num(report.countLoanOverDue),
+    foreclosureCount: num(report.countForeclosure),
+    alertNoticeCount: num(report.countAlertNotice),
+    akamCount: num(report.countAkam),
+    cancelledCount: num(report.countCancelled),
+  };
+
+  return {
+    currentBalance,
+    monthlyIncome,
+    monthlyExpenses,
+    monthlyNetCashFlow,
+    monthlyBalances,
+    monthsCovered,
+    deficitMonthsCount,
+    avgMonthlyIncome,
+    avgMonthlyExpense,
+    totalSavings,
+    totalSecuritiesValue,
+    totalInvestments,
+    securitiesCount,
+    totalLoans,
+    totalMortgage,
+    totalDebt,
+    hasActiveLoans: totalLoans > 0,
+    hasMortgage: totalMortgage > 0,
+    activeCreditCardsCount,
+    avgMonthlyCreditCardSpend,
+    creditCardFeesTotal,
+    savingsRate,
+    discretionarySurplus,
+    systemFlags,
+    hasData: true,
+  };
+}

--- a/src/open-finance/financial-report.types.ts
+++ b/src/open-finance/financial-report.types.ts
@@ -1,0 +1,133 @@
+/**
+ * Type definitions mirroring the REAL aggregated Open Finance `financialReport`
+ * payload (see carmelsData.json for a representative sample).
+ *
+ * These intentionally describe the payload that the provider actually returns —
+ * an aggregated report, NOT a flat transactions list. Every field is optional
+ * because the provider omits empty sections, so the extractor must defend
+ * against missing/partial data.
+ */
+
+/** A checking-account balance entry (`checkingAccountsILS[]` / `checkingAccounts[]`). */
+export interface OFCheckingAccount {
+  customerId?: string;
+  amount?: number;
+  providerId?: string;
+  accountNumber?: string;
+  accountId?: string;
+  currency?: string;
+}
+
+/** A single month's income/expense roll-up (`yearMonthBalance[]`). */
+export interface OFYearMonthBalance {
+  yearMonth?: string;
+  sumIncome?: number;
+  sumExpense?: number;
+}
+
+/** A regular income source inside `totalIncomesOutcome.regularIncomeSources[]`. */
+export interface OFRegularIncomeSource {
+  classificationSource?: string;
+  amount?: number;
+}
+
+/** Aggregated monthly income/expense summary (`totalIncomesOutcome`). */
+export interface OFTotalIncomesOutcome {
+  date?: string;
+  customerId?: string;
+  sumIncomePerMonth?: number;
+  sumExpansesPerMonth?: number;
+  sumNetIncomePerMonth?: number;
+  regularIncomeSources?: OFRegularIncomeSource[];
+}
+
+/** A credit-card monthly spend entry (`creditCardOutcomes[]`). */
+export interface OFCreditCardOutcome {
+  accountNumber?: string;
+  parsedAccountNumber?: string;
+  yearMonth?: string;
+  customerId?: string;
+  providerId?: string;
+  sumExpanse?: number;
+}
+
+/** Average card fee per card (`creditCardFees[]`). */
+export interface OFCreditCardFee {
+  avgCardFee?: number | null;
+  accountNumber?: string;
+  customerId?: string;
+  providerId?: string;
+}
+
+/** Savings & securities totals (`savingsAndSecurities`). */
+export interface OFSavingsAndSecurities {
+  customerId?: string;
+  totalSavings?: number;
+  totalSecuritiesValue?: number;
+  totalForeignCurrencyAmount?: unknown[];
+  foreignCurrency?: string;
+}
+
+/** A single security holding (`securities[]`). */
+export interface OFSecurity {
+  accountNumber?: string;
+  parsedAccountNumber?: string;
+  providerId?: string;
+  name?: string;
+  unitsNumber?: number;
+  averageBuyingPrice?: { amount?: number; currency?: string } | null;
+  normalisedPrice?: number | null;
+  totalValue?: number;
+}
+
+/** Loans & mortgage totals (`loansTotal`). */
+export interface OFLoansTotal {
+  customerId?: string;
+  totalMortgageAmount?: number;
+  totalLoansAmount?: number;
+}
+
+/**
+ * The aggregated financial report. Both the credit/BDI counters and the
+ * collection sections are optional — the provider omits empty ones.
+ */
+export interface OFFinancialReport {
+  currentDate?: string;
+  customerId?: string;
+  ownerName?: string;
+  parsedAccountNumber?: string;
+  providerId?: string;
+
+  checkingAccountsILS?: OFCheckingAccount[];
+  checkingAccounts?: OFCheckingAccount[];
+  yearMonthBalance?: OFYearMonthBalance[];
+  totalIncomesOutcome?: OFTotalIncomesOutcome;
+
+  creditCardOutcomes?: OFCreditCardOutcome[];
+  creditCardFees?: OFCreditCardFee[];
+
+  savingsAndSecurities?: OFSavingsAndSecurities;
+  savings?: unknown[];
+  securities?: OFSecurity[];
+
+  loansTotal?: OFLoansTotal;
+  loans?: unknown[];
+  totalLoans?: unknown[];
+
+  // BDI / credit-behaviour counters (null when the provider has no data).
+  countAkam?: number | null;
+  countAlertNotice?: number | null;
+  countCancelled?: number | null;
+  countForeclosure?: number | null;
+  countLoanOverDue?: number | null;
+}
+
+/**
+ * The top-level payload as returned by the Open Finance report job. The file
+ * upload flow receives this wrapper; the API flow receives the inner
+ * `financialReport` directly. The extractor's `normalizeReport` handles both.
+ */
+export interface OFReportEnvelope {
+  status?: string;
+  financialReport?: OFFinancialReport;
+}

--- a/src/open-finance/open-finance.module.ts
+++ b/src/open-finance/open-finance.module.ts
@@ -11,12 +11,16 @@ import { RoadmapStep } from '../database/entities/roadmap-step.entity.js';
 import { RoadmapGoal } from '../database/entities/roadmap-goal.entity.js';
 import { UserProfile } from '../database/entities/user-profile.entity.js';
 import { UserProfileHistory } from '../database/entities/user-profile-history.entity.js';
+import { FinancialAnalysisModule } from '../financial-analysis/financial-analysis.module.js';
+import { EventDetectionModule } from '../event-detection/event-detection.module.js';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([BankConsent, BankToken, RoadmapStep, RoadmapGoal, UserProfile, UserProfileHistory]),
     // Store uploaded files in memory so we can access file.buffer in the service.
     MulterModule.register({ storage: memoryStorage() }),
+    FinancialAnalysisModule,
+    EventDetectionModule,
   ],
   controllers: [OpenFinanceController],
   providers: [OpenFinanceService, OpenFinanceApiService],

--- a/src/open-finance/open-finance.service.ts
+++ b/src/open-finance/open-finance.service.ts
@@ -18,9 +18,12 @@ import {
 import { UserProfile } from '../database/entities/user-profile.entity.js';
 import { UserProfileHistory } from '../database/entities/user-profile-history.entity.js';
 import { LlmClientService } from '../llm-client/llm-client.service.js';
+import { extractFeatures } from './financial-report.extractor.js';
+import { FinancialFeatures } from './financial-features.model.js';
+import { FinancialAnalysisService } from '../financial-analysis/financial-analysis.service.js';
+import { EventDetectionService } from '../event-detection/event-detection.service.js';
 
 export interface AiCriteriaProfile {
-  current_step: number;
   cash_flow: number;
   credit_consumption: number;
   loans: number;
@@ -112,6 +115,8 @@ export class OpenFinanceService {
     private readonly historyRepo: Repository<UserProfileHistory>,
     private readonly dataSource: DataSource,
     private readonly llm: LlmClientService,
+    private readonly financialAnalysis: FinancialAnalysisService,
+    private readonly eventDetection: EventDetectionService,
   ) {}
 
   async connect(body: any) {
@@ -177,8 +182,25 @@ export class OpenFinanceService {
       );
     }
 
-    // 2. Deterministic preprocessing — token diet.
-    const summaryJson = this.preprocessBankingData(bankingData);
+    // 2. Deterministic feature extraction from the aggregated Open Finance
+    //    report. Replaces the old transactions-based preprocessing — the real
+    //    payload is an aggregated report, not a flat transactions list.
+    const features: FinancialFeatures = extractFeatures(bankingData);
+    const summaryJson = JSON.stringify(features);
+
+    // 2a. Persist the raw snapshot and detect data-backed events. These run in
+    //     parallel with the LLM round-trips below; they don't block them.
+    const sideEffects = Promise.all([
+      this.financialAnalysis.persistSnapshot(userId, features),
+      this.eventDetection.detectEvents(userId, features),
+    ]).catch((err) => {
+      // Snapshot/event persistence is non-critical to the analysis result.
+      this.logger.warn(
+        `Snapshot/event persistence failed — userId=${userId}: ${String(
+          err?.message,
+        ).slice(0, 160)}`,
+      );
+    });
 
     // 2b. Load the user's existing state & task history in PARALLEL with the LLM
     //     calls. It is only consumed by the reconciliation step, so there is no
@@ -220,6 +242,9 @@ export class OpenFinanceService {
         JSON.stringify(clientResponse, null, 2),
     );
 
+    // Ensure snapshot/event persistence has settled before responding.
+    await sideEffects;
+
     const __elapsed = Date.now() - __t0;
     this.logger.log(
       `analyzeBankingJson END — userId=${userId} took ${__elapsed} ms ` +
@@ -227,151 +252,6 @@ export class OpenFinanceService {
     );
 
     return clientResponse;
-  }
-
-  // ─── TASK 1: Deterministic Data Aggregation ────────────────────────────────
-
-  private preprocessBankingData(rawData: unknown): string {
-    if (
-      rawData == null ||
-      (typeof rawData === 'object' &&
-        !Array.isArray(rawData) &&
-        Object.keys(rawData as object).length === 0)
-    ) {
-      return JSON.stringify({
-        metrics: {
-          totalMonthlyIncome: 0,
-          totalMonthlyExpenses: 0,
-          totalMonthlySavingsInvestments: 0,
-          totalMonthlyDebtPayments: 0,
-          netCashFlow: 0,
-          discretionarySurplus: 0,
-          savingsRate: 0,
-          currentBalance: 0,
-        },
-        aggregatedCategories: [],
-        highImpactTransactions: [],
-      });
-    }
-
-    const data = rawData as Record<string, any>;
-    const transactions: Array<Record<string, any>> = Array.isArray(
-      data.transactions,
-    )
-      ? data.transactions
-      : Array.isArray(data)
-        ? (data as any[])
-        : [];
-
-    // Calculate financial metrics
-    let totalMonthlyIncome = 0;
-    let totalMonthlyExpenses = 0;
-    // Money intentionally directed toward wealth-building (NOT a living cost).
-    let totalMonthlySavingsInvestments = 0;
-    // Loan / mortgage repayments (debt servicing, tracked separately).
-    let totalMonthlyDebtPayments = 0;
-    const currentBalance: number =
-      typeof data.balance === 'number'
-        ? data.balance
-        : typeof data.currentBalance === 'number'
-          ? data.currentBalance
-          : 0;
-
-    // Outflows that build net worth rather than consume it — these must NOT be
-    // counted as expenses, otherwise a disciplined investor looks cash-negative.
-    const SAVINGS_INVEST_KEYWORDS =
-      /invest|pension|saving|provident|gemel|securities|stock|etf|fund|deposit|השקע|פנסי|חיסכו|חסכו|גמל|השתלמות|ניירות ערך|מניות|קרן סל|קרן נאמנות|פיקדון|חיסכון/i;
-    // Debt servicing — informative but distinct from discretionary spending.
-    const DEBT_KEYWORDS =
-      /loan|mortgage|repayment|הלוואה|משכנתא|החזר הלוואה|החזר משכנתא/i;
-    const HIGH_IMPACT_KEYWORDS =
-      /loan|הלוואה|mortgage|משכנתא|overdraft|מינוס|עמלה|invest|השקע|pension|פנסי|גמל|השתלמות/i;
-    const HIGH_AMOUNT_THRESHOLD = 1000;
-
-    const highImpactTransactions: Array<Record<string, any>> = [];
-    const categoryBuckets = new Map<string, { sum: number; count: number }>();
-
-    for (const tx of transactions) {
-      const amount =
-        typeof tx.amount === 'number' ? tx.amount : Number(tx.amount) || 0;
-      const absAmount = Math.abs(amount);
-      const description: string = tx.description ?? tx.memo ?? tx.name ?? '';
-      const category: string = tx.category ?? tx.type ?? 'uncategorized';
-      const haystack = `${category} ${description}`;
-
-      // Income vs outflow classification. Outflows are split into three buckets
-      // so the LLM can tell consumption apart from wealth-building and debt.
-      if (amount > 0) {
-        totalMonthlyIncome += amount;
-      } else if (SAVINGS_INVEST_KEYWORDS.test(haystack)) {
-        totalMonthlySavingsInvestments += absAmount;
-      } else if (DEBT_KEYWORDS.test(haystack)) {
-        totalMonthlyDebtPayments += absAmount;
-      } else {
-        totalMonthlyExpenses += absAmount;
-      }
-
-      // High-impact retention: keep raw if amount > threshold or keyword match
-      const isHighAmount = absAmount > HIGH_AMOUNT_THRESHOLD;
-      const isKeywordMatch =
-        HIGH_IMPACT_KEYWORDS.test(description) ||
-        HIGH_IMPACT_KEYWORDS.test(category);
-
-      if (isHighAmount || isKeywordMatch) {
-        highImpactTransactions.push(tx);
-      } else {
-        // Aggregate low-value transactions by category
-        const bucket = categoryBuckets.get(category);
-        if (bucket) {
-          bucket.sum += absAmount;
-          bucket.count += 1;
-        } else {
-          categoryBuckets.set(category, { sum: absAmount, count: 1 });
-        }
-      }
-    }
-
-    // Format aggregated categories
-    const aggregatedCategories: string[] = [];
-    for (const [cat, { sum, count }] of categoryBuckets) {
-      aggregatedCategories.push(
-        `${cat}: ${Math.round(sum)} ILS across ${count} transactions`,
-      );
-    }
-
-    // Derived health indicators.
-    // discretionarySurplus = what's left after living costs + debt, BEFORE voluntary
-    //   saving/investing. Positive here means the user can afford to build wealth.
-    // netCashFlow = actual change in liquid cash after everything (incl. investing).
-    //   It can be negative for a healthy investor who deploys their surplus.
-    const discretionarySurplus =
-      totalMonthlyIncome - totalMonthlyExpenses - totalMonthlyDebtPayments;
-    const netCashFlow = discretionarySurplus - totalMonthlySavingsInvestments;
-    const savingsRate =
-      totalMonthlyIncome > 0
-        ? Math.round(
-            (totalMonthlySavingsInvestments / totalMonthlyIncome) * 100,
-          )
-        : 0;
-
-    const summary = {
-      metrics: {
-        totalMonthlyIncome: Math.round(totalMonthlyIncome),
-        totalMonthlyExpenses: Math.round(totalMonthlyExpenses),
-        totalMonthlySavingsInvestments: Math.round(
-          totalMonthlySavingsInvestments,
-        ),
-        totalMonthlyDebtPayments: Math.round(totalMonthlyDebtPayments),
-        netCashFlow: Math.round(netCashFlow),
-        discretionarySurplus: Math.round(discretionarySurplus),
-        savingsRate,
-        currentBalance: Math.round(currentBalance),
-      },
-      aggregatedCategories,
-      highImpactTransactions,
-    };
-
-    return JSON.stringify(summary);
   }
 
   // ─── TASK 2 & 3: 2-Wave LLM Pipeline with Validation ─────────────────────
@@ -396,17 +276,20 @@ export class OpenFinanceService {
 
     const systemPrompt = [
       'You are an expert Israeli financial analyst.',
-      'Evaluate the user financial summary below and return a JSON object representing their profile.',
+      'Evaluate the user financial features below and return a JSON object representing their profile.',
       '',
-      '## How to read the metrics block',
-      '- totalMonthlyIncome: all incoming money (salary, dividends, interest).',
-      '- totalMonthlyExpenses: TRUE living/consumption costs only (rent, groceries, utilities, leisure).',
-      '- totalMonthlySavingsInvestments: money the user DELIBERATELY moves into wealth-building (investments, pension, provident funds, savings). This is a STRENGTH, never a deficit or a problem.',
-      '- totalMonthlyDebtPayments: loan/mortgage servicing.',
-      '- discretionarySurplus = income - expenses - debt. This is the real cash-flow health signal: POSITIVE means the user lives within their means and can build wealth.',
-      '- netCashFlow = discretionarySurplus - savingsInvestments. A NEGATIVE netCashFlow combined with a POSITIVE discretionarySurplus is HEALTHY — it means the user is investing their surplus, not overspending. Do NOT treat this as financial distress.',
-      '- savingsRate: % of income directed to savings/investments. Higher = more advanced.',
-      'Judge cash_flow on discretionarySurplus (and expenses vs income), NOT on netCashFlow. Reward high savingsRate and active investing/pension when scoring savings_investments and pension_long_term.',
+      '## How to read the financial features block (all amounts in ILS, monthly unless noted)',
+      '- currentBalance: total liquid balance across all checking accounts.',
+      '- monthlyIncome / monthlyExpenses: provider-aggregated average monthly income and spending.',
+      '- monthlyNetCashFlow: provider-reported income minus expenses per month.',
+      '- discretionarySurplus = monthlyIncome - monthlyExpenses. POSITIVE means the user lives within their means and can build wealth.',
+      '- savingsRate: % of monthly income left as surplus. Higher = more capacity to save/invest.',
+      '- monthsCovered / avgMonthlyIncome / avgMonthlyExpense / deficitMonthsCount: the multi-month trend. deficitMonthsCount = number of months where expense exceeded income.',
+      '- totalSavings / totalSecuritiesValue / totalInvestments / securitiesCount: accumulated wealth. A LARGE totalInvestments is a STRENGTH, never a deficit, and points to the higher stages.',
+      '- totalLoans / totalMortgage / totalDebt / hasActiveLoans / hasMortgage: outstanding debt.',
+      '- activeCreditCardsCount / avgMonthlyCreditCardSpend / creditCardFeesTotal: credit-card usage.',
+      '- systemFlags (loanOverDueCount, foreclosureCount, alertNoticeCount, akamCount, cancelledCount): BDI distress counters. Any non-zero value signals instability — score system_indicators lower.',
+      'Judge cash_flow on discretionarySurplus and the deficitMonthsCount trend. Reward high totalInvestments / savingsRate when scoring savings_investments and pension_long_term. Score loans/mortgage from totalDebt, and system_indicators worse when systemFlags are non-zero.',
       '',
       '## 8 Granular Financial Criteria — Stage Definitions',
       criteriaByStageSection,
@@ -417,7 +300,6 @@ export class OpenFinanceService {
       '',
       '## Required Output Schema (flat JSON object):',
       JSON.stringify({
-        current_step: '<integer 1–5, weighted synthesis>',
         cash_flow: '<integer 1–5>',
         credit_consumption: '<integer 1–5>',
         loans: '<integer 1–5>',
@@ -547,7 +429,7 @@ export class OpenFinanceService {
           .join('\n\n')
       : '  (user has no existing tasks — this is a first assessment)';
 
-    const priorStep = context.currentState?.currentStepId ?? null;
+    const priorStep = context.currentProfile?.currentStep ?? null;
     const priorProgress = context.currentState?.progressPercent ?? null;
 
     const historySection = context.history.length
@@ -569,11 +451,11 @@ export class OpenFinanceService {
       "2) RECONCILE the user's existing tasks against that determined stage and",
       '   return an ID-based reconciliation diff.',
       '',
-      '## How to read the metrics block',
-      '- totalMonthlyExpenses is TRUE living costs only. Money in totalMonthlySavingsInvestments (investments, pension, savings) is wealth-building, NOT spending.',
-      '- discretionarySurplus = income - expenses - debt. POSITIVE = healthy cash flow. Judge cash flow on THIS, not on netCashFlow.',
-      '- A NEGATIVE netCashFlow with a POSITIVE discretionarySurplus is HEALTHY: the user is deploying surplus into wealth-building. NEVER classify such a user as Stage 1 and NEVER describe it as a "negative cash flow" or deficit.',
-      '- Active investing + pension + high savingsRate point toward the HIGHER stages (4–5).',
+      '## How to read the financial features block (all amounts in ILS, monthly unless noted)',
+      '- discretionarySurplus = monthlyIncome - monthlyExpenses. POSITIVE = healthy cash flow; a comfortable surplus is a STRENGTH.',
+      '- A large totalInvestments / totalSecuritiesValue is wealth-building and a STRENGTH — never describe it as a deficit. Such users point toward the HIGHER stages (4–5).',
+      '- deficitMonthsCount across monthsCovered shows cash-flow stability; more deficit months ⇒ weaker cash flow.',
+      '- systemFlags (loanOverDueCount, foreclosureCount, alertNoticeCount) non-zero ⇒ instability/distress.',
       '',
       '## Financial Stage Definitions',
       stagesSection,
@@ -591,6 +473,7 @@ export class OpenFinanceService {
       '- Put tasks that are no longer relevant (e.g. left over from a previous step) into "remove".',
       '- Put tasks the data shows are achieved into "complete".',
       '- Only "add" templates that are genuinely relevant and not already assigned.',
+      '- When adding a goal, fill dynamic_params with REAL numbers taken from the financial features block (e.g. surplus, currentBalance, activeCreditCardsCount, totalInvestments). NEVER invent figures; if a value is not derivable from the features, use null.',
       '',
       `## User's Current Pyramid Level: ${priorStep ?? 'unknown'} (progress ${priorProgress ?? 0}%)`,
       '',
@@ -683,11 +566,13 @@ export class OpenFinanceService {
     };
   }
 
-  /** Coerce all integer criteria fields to numbers, clamp to 1–5, and keep strings as strings. */
+  /**
+   * Coerce all criteria fields to numbers clamped to 1–5 (defaulting to 1) so a
+   * malformed LLM payload can never persist an out-of-range score.
+   */
   private normalizeCriteriaProfile(raw: any): AiCriteriaProfile {
     const clamp = (v: any) => Math.min(5, Math.max(1, Number(v) || 1));
     return {
-      current_step: clamp(raw?.current_step),
       cash_flow: clamp(raw?.cash_flow),
       credit_consumption: clamp(raw?.credit_consumption),
       loans: clamp(raw?.loans),
@@ -730,7 +615,7 @@ export class OpenFinanceService {
         .map((g) => g.goalId),
     );
 
-    const priorStep = params.context.currentState?.currentStepId ?? null;
+    const priorStep = params.context.currentProfile?.currentStep ?? null;
     const priorProgress = params.context.currentState?.progressPercent ?? null;
     const newProgress = params.roadmapState.progress_percentage;
 
@@ -742,7 +627,6 @@ export class OpenFinanceService {
       if (!state) {
         state = manager.create(RoadmapState, { userId });
       }
-      state.currentStepId = currentStep;
       state.progressPercent = newProgress;
       state.stateDescription = params.roadmapState.state_description;
       const savedState = await manager.save(RoadmapState, state);
@@ -752,7 +636,7 @@ export class OpenFinanceService {
       if (!profile) {
         profile = manager.create(UserProfile, { userId });
       }
-      profile.currentStep = p.current_step;
+      profile.currentStep = currentStep;
       profile.cashFlow = p.cash_flow;
       profile.creditConsumption = p.credit_consumption;
       profile.loans = p.loans;

--- a/src/roadmap/roadmap.module.ts
+++ b/src/roadmap/roadmap.module.ts
@@ -4,9 +4,12 @@ import { RoadmapController } from './roadmap.controller.js';
 import { RoadmapService } from './roadmap.service.js';
 import { RoadmapStep } from '../database/entities/roadmap-step.entity.js';
 import { RoadmapState } from '../database/entities/roadmap-state.entity.js';
+import { UserProfile } from '../database/entities/user-profile.entity.js';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([RoadmapStep, RoadmapState])],
+  imports: [
+    TypeOrmModule.forFeature([RoadmapStep, RoadmapState, UserProfile]),
+  ],
   controllers: [RoadmapController],
   providers: [RoadmapService],
   exports: [RoadmapService],

--- a/src/roadmap/roadmap.service.ts
+++ b/src/roadmap/roadmap.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { RoadmapStep } from '../database/entities/roadmap-step.entity.js';
 import { RoadmapState } from '../database/entities/roadmap-state.entity.js';
+import { UserProfile } from '../database/entities/user-profile.entity.js';
 
 @Injectable()
 export class RoadmapService {
@@ -11,24 +12,49 @@ export class RoadmapService {
     private readonly stepRepo: Repository<RoadmapStep>,
     @InjectRepository(RoadmapState)
     private readonly stateRepo: Repository<RoadmapState>,
+    @InjectRepository(UserProfile)
+    private readonly profileRepo: Repository<UserProfile>,
   ) {}
 
   async getRoadmap(userId: string) {
-    const state = await this.stateRepo.findOne({
-      where: { userId },
-      relations: ['currentStep'],
-    });
-    const steps = await this.stepRepo.find({ order: { stepId: 'ASC' } });
-    return { state, steps };
+    const [state, profile, steps] = await Promise.all([
+      this.stateRepo.findOne({ where: { userId } }),
+      this.profileRepo.findOne({ where: { userId } }),
+      this.stepRepo.find({ order: { stepId: 'ASC' } }),
+    ]);
+
+    // current_step is owned by user_profiles; resolve the matching step row for
+    // the client visualization.
+    const currentStepId = profile?.currentStep ?? null;
+    const currentStep =
+      currentStepId != null
+        ? (steps.find((s) => s.stepId === currentStepId) ?? null)
+        : null;
+
+    return { state, currentStepId, currentStep, steps };
   }
 
-  async updateRoadmap(userId: string, body: { currentStepId?: number; progressPercent?: number }) {
+  async updateRoadmap(
+    userId: string,
+    body: { currentStepId?: number; progressPercent?: number },
+  ) {
+    // The user's current step is the single source of truth on user_profiles.
+    if (body.currentStepId !== undefined) {
+      let profile = await this.profileRepo.findOne({ where: { userId } });
+      if (!profile) {
+        profile = this.profileRepo.create({ userId });
+      }
+      profile.currentStep = body.currentStepId;
+      await this.profileRepo.save(profile);
+    }
+
     let state = await this.stateRepo.findOne({ where: { userId } });
     if (!state) {
-      state = this.stateRepo.create({ userId, progressPercent: 0, currentStepId: body.currentStepId ?? 1 });
+      state = this.stateRepo.create({ userId, progressPercent: 0 });
     }
-    if (body.currentStepId !== undefined) state.currentStepId = body.currentStepId;
-    if (body.progressPercent !== undefined) state.progressPercent = body.progressPercent;
+    if (body.progressPercent !== undefined) {
+      state.progressPercent = body.progressPercent;
+    }
     return this.stateRepo.save(state);
   }
 }


### PR DESCRIPTION
…l snapshots

feat(llm-orchestrator): implement persistGuidanceLog for AI guidance logging

feat(open-finance): integrate FinancialAnalysisModule and EventDetectionModule

feat(open-finance): refactor to extract financial features and persist snapshots/events

refactor(roadmap): update roadmap service to use user profile for current step management

fix(migration): remove redundant current_step_id from roadmap_states and backfill user_profiles

feat(open-finance): create financial features model and extractor for structured financial data

feat(open-finance): define types for Open Finance financial report payload